### PR TITLE
Add generic function for finding intersection of songs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .run
 __pycache__/
 node_modules/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 Analyze music playlists
+
+
+## Server stuff
+
+To run the unit tests:
+
+```
+python -m unittest discover
+```
+from within the top-level directory of this project

--- a/server/analyzer.py
+++ b/server/analyzer.py
@@ -19,15 +19,17 @@ def get_total_duration(songs):
 
 
 def find_common_songs(songs1, songs2):
-    # TODO: probably can do this more succinctly.. more... better
-    # I'm sure you can filter on object properties
-    match_list_2 = ["{}{}".format(song.title, song.artist) for song in songs2]
-    return [song for song in songs1 if "{}{}".format(song.title, song.artist) in match_list_2]
+    return song_intersection(songs1, songs2, lambda song: "{}{}".format(song.title, song.artist))
 
 
-# TODO: make a generic intersection func for these public funcs
 def find_common_artists(songs1, songs2):
-    artists1 = [song.artist for song in songs1]
-    artists2 = [song.artist for song in songs2]
+    matching_songs = song_intersection(songs1, songs2, "artist")
+    return [song.artist for song in matching_songs]
 
-    return list(set(artists1).intersection(set(artists2)))
+
+def song_intersection(songs1, songs2, attribute):
+    attribute_getter = attribute if callable(attribute) else lambda x: getattr(x, attribute)
+    
+    attrs = {attribute_getter(x) for x in songs1} & {attribute_getter(x) for x in songs2}
+
+    return [song for song in songs1 if attribute_getter(song) in attrs]

--- a/server/test_analyzer.py
+++ b/server/test_analyzer.py
@@ -1,0 +1,89 @@
+import unittest
+from uuid import uuid4
+
+from .serializers import Song
+from .analyzer import song_intersection, find_common_songs, find_common_artists
+
+
+class SongIntersectionTests(unittest.TestCase):
+    common1, common2, songs1, songs2 = [None, None, [], []]
+
+    def setUp(self):
+        _init_sample_songs(self)
+
+    def test_basic_case_with_simple_attribute(self):
+        expected = {self.common1, self.common2}
+
+        common_songs = song_intersection(self.songs1, self.songs2, "artist")
+
+        self.assertEqual(expected, set(common_songs))
+
+    def test_basic_case_with_computed_attribute(self):
+        attribute_getter = lambda x: "{}{}".format(x.title, x.artist)
+        expected = {self.common1, self.common2}
+
+        common_songs = song_intersection(self.songs1, self.songs2, attribute_getter)
+
+        self.assertEqual(expected, set(common_songs))
+
+class FindCommonSongs(unittest.TestCase):
+    common1, common2, songs1, songs2 = [None, None, [], []]
+
+    def setUp(self):
+        _init_sample_songs(self)
+
+    def test_basic_case(self):
+        expected = {self.common1, self.common2}
+
+        matches = find_common_songs(self.songs1, self.songs2)
+
+        self.assertEqual(expected, set(matches))
+
+    def test_no_common_songs(self):
+        self.songs1 = [_random_song() for _ in range(10)]
+        self.songs2 = [_random_song() for _ in range(10)]
+
+        matches = find_common_songs(self.songs1, self.songs2)
+
+        self.assertEqual([], matches)
+
+
+class FindCommonArtists(unittest.TestCase):
+    common1, common2, songs1, songs2 = [None, None, [], []]
+
+    def setUp(self):
+        _init_sample_songs(self)
+
+    def test_basic_case(self):
+        expected = {self.common1.artist, self.common2.artist}
+
+        matches = find_common_artists(self.songs1, self.songs2)
+
+        self.assertEqual(expected, set(matches))
+
+    def test_no_common_songs(self):
+        self.songs1 = [_random_song() for _ in range(10)]
+        self.songs2 = [_random_song() for _ in range(10)]
+
+        matches = find_common_artists(self.songs1, self.songs2)
+
+        self.assertEqual([], matches)
+
+        
+def _init_sample_songs(self):
+    # set up two collections of songs with two songs in common
+    self.common1 = Song("titlecommon1", "albulmcommon1",
+                        "artistcommon1", "popularitycommon1", 100)
+    self.common2 = Song("titlecommon2", "albulmcommon2",
+                        "artistcommon2", "popularitycommon2", 150)
+
+    self.songs1 = [_random_song() for _ in range(10)]
+    self.songs2 = [_random_song() for _ in range(10)]
+    self.songs1[3] = self.common1
+    self.songs1[0] = self.common2
+    self.songs2[-1] = self.common1
+    self.songs2[-3] = self.common2
+
+def _random_song():
+    # generate a song with random data
+    return Song(str(uuid4()), str(uuid4()), str(uuid4()), str(uuid4()), str(uuid4()))


### PR DESCRIPTION
Stumbled across the comment in analyzer.py about creating a generic intersection function, so I did that as it'd be a fun little task.

Adds ```song_intersection``` which matches all songs in common between two collections of songs based upon either an attribute or a value computed from a function.  Updated the ```find_common_songs``` and ```find_common_artists``` to demonstrate use.